### PR TITLE
Remove unused datapunt-authorization-django middleware

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -22,9 +22,6 @@ celery==4.3.0
 django-celery-email==2.0.2
 # Database
 psycopg2-binary==2.8.4
-# Datapunt packages
-datapunt-authorization-django==0.3.1
-datapunt-authorization-levels==0.1.3
 # Validation
 swagger-spec-validator==2.4.3
 # Logging

--- a/api/requirements/req-base.txt
+++ b/api/requirements/req-base.txt
@@ -30,10 +30,6 @@ django-celery-email
 # Database
 psycopg2-binary
 
-# Datapunt packages
-datapunt-authorization-django
-datapunt-authorization-levels
-
 # Validation
 swagger-spec-validator
 

--- a/api/src/iot/settings/settings.py
+++ b/api/src/iot/settings/settings.py
@@ -194,11 +194,6 @@ JWKS_TEST_KEY = """
     }
 """
 
-DATAPUNT_AUTHZ = {
-    'JWKS': os.getenv('PUB_JWKS', JWKS_TEST_KEY),
-    'ALWAYS_OK': False,
-}
-
 # Django cache settings
 CACHES = {
     'default': {


### PR DESCRIPTION
It seems this middleware isn't used (anymore), so let's clean it up.