### PR TITLE
TAO-784 : Fix latitude / longitude

### DIFF
--- a/api/src/iot/import_utils.py
+++ b/api/src/iot/import_utils.py
@@ -416,7 +416,7 @@ def get_location(sensor_data: SensorData):
     elif isinstance(sensor_data.location, LatLong):
         return {'location': Point(sensor_data.location.longitude, sensor_data.location.latitude)}
     elif isinstance(sensor_data.location, LocationDescription):
-        return {'location_description': dataclasses.astuple(sensor_data.location)}
+        return {'location_description': sensor_data.location.description}
     elif isinstance(sensor_data.location, PostcodeHouseNumber):
         location = get_center_coordinates(
             sensor_data.location.postcode,

--- a/api/src/iot/import_utils.py
+++ b/api/src/iot/import_utils.py
@@ -414,7 +414,7 @@ def get_location(sensor_data: SensorData):
     if isinstance(sensor_data.location, Regions):
         return {'regions': sensor_data.location.regions}
     elif isinstance(sensor_data.location, LatLong):
-        return {'location': Point(*dataclasses.astuple(sensor_data.location))}
+        return {'location': Point(sensor_data.location.longitude, sensor_data.location.latitude)}
     elif isinstance(sensor_data.location, LocationDescription):
         return {'location_description': dataclasses.astuple(sensor_data.location)}
     elif isinstance(sensor_data.location, PostcodeHouseNumber):

--- a/api/src/iot/serializers.py
+++ b/api/src/iot/serializers.py
@@ -226,9 +226,9 @@ class Device2Serializer(HALSerializer):
             'legal_ground',
             'privacy_declaration',
             'active_until',
-            'reference'
+            'reference',
         ]
 
     def get_location(self, obj):
         if obj.location:
-            return {'latitude': obj.location.x, 'longitude': obj.location.y}
+            return {'latitude': obj.location.y, 'longitude': obj.location.x}

--- a/api/src/iot/tests/test_import_utils.py
+++ b/api/src/iot/tests/test_import_utils.py
@@ -319,7 +319,7 @@ class TestImportSensor:
     def test_import_sensor_location(self, sensor_data):
         # check that the location is imported correctly
         owner = import_utils.import_person(sensor_data.owner)
-        sensor_data.location = import_utils.LatLong(52.3676, 4.9041)
+        sensor_data.location = import_utils.LatLong(latitude=52.3676, longitude=4.9041)
         import_utils.import_sensor(sensor_data, owner)
         location = {"latitude": 52.3676, "longitude": 4.9041}
         assert self.actual == [dict(self.expected, location_description=None, location=location)]
@@ -351,7 +351,7 @@ class TestImportSensor:
         # check that we can import a location based on postcode and house number
         owner = import_utils.import_person(sensor_data.owner)
         sensor_data.location = import_utils.PostcodeHouseNumber("1111AA", 1)
-        with patch('iot.import_utils.get_center_coordinates', lambda *_: Point(52.3676, 4.9041)):
+        with patch('iot.import_utils.get_center_coordinates', lambda *_: Point(4.9041, 52.3676)):
             import_utils.import_sensor(sensor_data, owner)
         location = {"latitude": 52.3676, "longitude": 4.9041}
         assert self.actual == [dict(self.expected, location_description=None, location=location)]


### PR DESCRIPTION
Op een aantal plekken in zowel de backend als de frontend werden latitude en longitude omgekeerd. In deze PR worden de plekken in de backend aangepast om punten goed te importeren en terug te geven in de API. 