### PR TITLE
TAO-784: Fix incorrect expected value for location description

### DIFF
--- a/api/src/iot/tests/test_import_utils.py
+++ b/api/src/iot/tests/test_import_utils.py
@@ -270,7 +270,7 @@ class TestImportSensor:
         'datastream': 'water',
         'legal_ground': 'Publieke taak',
         'location': None,
-        'location_description': "('Somewhere over the rainbow',)",
+        'location_description': "Somewhere over the rainbow",
         'observation_goal': 'Nare bedoelingen',
         'owner': {
             'name': 'Piet Er Soon',


### PR DESCRIPTION
Ik had in deze branch een fix gemaakt voor de location omschrijving, maar was vergeten de onjuiste waarde in de test aan te passen.