### PR TITLE
TAO-785: Redirect naar 403 pagina

### DIFF
--- a/api/src/iot/settings/settings.py
+++ b/api/src/iot/settings/settings.py
@@ -40,7 +40,7 @@ X_FRAME_OPTIONS = 'DENY'
 
 ## KEYCLOAK ##
 # External identity provider settings (Keycloak)
-LOGIN_REDIRECT_URL = "/iothings/admin"
+LOGIN_REDIRECT_URL = "/iothings/admin/"
 OIDC_RP_CLIENT_ID = os.environ['OIDC_RP_CLIENT_ID']
 OIDC_RP_CLIENT_SECRET = os.environ['OIDC_RP_CLIENT_SECRET']
 OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ['OIDC_OP_AUTHORIZATION_ENDPOINT']
@@ -48,7 +48,7 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ['OIDC_OP_TOKEN_ENDPOINT']
 OIDC_OP_USER_ENDPOINT = os.environ['OIDC_OP_USER_ENDPOINT']
 OIDC_OP_JWKS_ENDPOINT = os.environ['OIDC_OP_JWKS_ENDPOINT']
 OIDC_OP_LOGOUT_ENDPOINT = LOGOUT_REDIRECT_URL = os.environ['OIDC_OP_LOGOUT_ENDPOINT']
-
+LOGIN_REDIRECT_URL_FAILURE = '/iothings/static/403.html'
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/api/src/iot/static/403.html
+++ b/api/src/iot/static/403.html
@@ -1,0 +1,116 @@
+<html lang="nl"><head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="https://fast.fonts.net/cssapi/3680cf49-2b05-4b8a-af28-fa9e27d2bed0.css">
+    <link href="https://data.amsterdam.nl/favicon.png" rel="shortcut icon">
+    <title>Toegang geweigerd (403)</title>
+    <style>
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-family: "Avenir LT W01 55 Roman", Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.25;
+    color: #000;
+}
+a {
+    color: #000;
+}
+a:hover {
+    color: #ec0000;
+    text-decoration: underline;
+}
+h1 {
+    margin: 20px 0 10px 20px;
+    line-height: 26px;
+    font-size: 26px;
+    font-family: "Avenir LT W01 85 Heavy", Arial, sans-serif;
+    font-weight: normal;
+}
+h2 {
+    margin: 0 0 30px 20px;
+    line-height: 1.25;
+    font-size: 18px;
+    max-width: 734px;
+}
+p {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+.header {
+    display: block;
+    height: 50px;
+    border-bottom: 2px #999 solid;
+}
+.header_logo {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+}
+.header_title {
+    line-height: 50px;
+    color: #000;
+    margin-left: 85px;
+    font-family: "Avenir LT W01 85 Heavy", Arial, sans-serif;
+    font-weight: normal;
+}
+.header a {
+    text-decoration:none;
+}
+.c-page {
+    margin: 0;
+}
+.c-page__left-margin {
+    width: 20px;
+    float: left;
+}
+.c-page__content {
+    margin-left: 20px;
+}
+.c-page__logo {
+    width: 19px;
+    height: 50px;
+}
+.c-page__header {
+    height: 32px;
+    padding: 9px 0 9px 6px;
+    background-color: #333;
+    color: #fff;
+    font-size: 24px;
+}
+.c-page__toegang-geweigerd {
+    height: 24px;
+    line-height: 24px;
+    margin: 0 0 20px 0;
+    padding: 4px 0 5px 10px;
+    background-color: #ec0000;
+    color: #fff;
+    font-size: 16px;
+}
+.c-page__alleen-toegankelijk {
+    height: 26px;
+    font-size: 26px;
+    font-family: "Avenir LT W01 85 Heavy", Arial, sans-serif;
+}
+.c-page__heeft-u-vragen {
+    height: 16px;
+    margin-top: 30px;
+    font-size: 16px;
+}
+</style>
+    </head>
+    <body>
+<div class="header"> <a href="https://data.amsterdam.nl/" title="Naar voorpagina Dataportaal">
+<img class="header_logo" src="data:image/svg+xml;base64,PHN2ZyBpZD0ibG9nb18xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3NTQuNzggMzQwLjE5Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2VjMDAwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkFydGJvYXJkIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTIyNi4xNyw4NC4zOWE2OS44OCw2OS44OCwwLDAsMS0zMy40LDhjLTI0Ljg1LDAtNDIuNjQtMTYuODctNDIuNjQtNDIuMDYsMC0yNS44OCwxNy43OS00Mi43NSw0Mi42NC00Mi43NSwxMi4zMSwwLDIzLjM3LDIuNjIsMzEuODEsMTAuMTRMMjE0LDI4LjQyYy01LjEzLTUtMTMtNy44Ny0yMS4wOS03Ljg3LTE2LjY0LDAtMjcuNywxMi43Ny0yNy43LDI4Ljg0LDAsMTcuMjIsMTEuMDYsMzAsMjcuNywzMCw3LjMsMCwxMy45MS0xLjM2LDE4LjkzLTQuMjF2LTE5SDE5NS4yOHYtMTNoMzAuODlaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMjUyLjg1LDY3Ljc1Yy45MSw4LjA5LDcuMDcsMTMsMTQuNywxMyw2Ljg0LDAsMTEuMjktMy4xOSwxNC43MS03LjQxbDkuOCw3LjQxYTI4LjQ3LDI4LjQ3LDAsMCwxLTIzLjE0LDExYy0xNi41MywwLTI5Ljc1LTExLjUyLTI5Ljc1LTI4LjczczEzLjIyLTI4LjczLDI5Ljc1LTI4LjczQzI4NC4yLDM0LjIzLDI5NC41Nyw0NSwyOTQuNTcsNjR2My43NlptMjgtMTAuMjZjLS4xMS04LTUuMzYtMTMtMTMuOTEtMTMtOC4wOSwwLTEzLjExLDUuMTMtMTQuMTMsMTNaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMzA2Ljc3LDM1LjZoMTN2OC41NUgzMjBjMi40LTUuMTMsNy42NC05LjkyLDE2Ljc2LTkuOTIsOC40NCwwLDE0LjI1LDMuMzEsMTcuMSwxMC4xNSw0LTcsOS44LTEwLjE1LDE4LTEwLjE1LDE0LjU5LDAsMTkuNzIsMTAuMzgsMTkuNzIsMjMuNDl2MzIuNkgzNzcuOXYtMzFjMC02Ljg0LTItMTIuNzctMTAuMTQtMTIuNzctOC41NSwwLTExLjc0LDcuMDctMTEuNzQsMTQuMTRWOTAuMzJIMzQyLjM0VjU3LjcyYzAtNi43My0yLjc0LTExLjE4LTkuMzUtMTEuMTgtOSwwLTEyLjU0LDYuNjItMTIuNTQsMTMuOTFWOTAuMzJIMzA2Ljc3WiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTQxNy40Niw2Ny43NWMuOTEsOC4wOSw3LjA3LDEzLDE0LjcxLDEzLDYuODQsMCwxMS4yOC0zLjE5LDE0LjctNy40MWw5LjgxLDcuNDFhMjguNSwyOC41LDAsMCwxLTIzLjE0LDExQzQxNyw5MS42OSw0MDMuNzgsODAuMTcsNDAzLjc4LDYzUzQxNywzNC4yMyw0MzMuNTQsMzQuMjNjMTUuMjcsMCwyNS42NSwxMC43MiwyNS42NSwyOS43NnYzLjc2Wm0yOC4wNS0xMC4yNmMtLjEyLTgtNS4zNi0xMy0xMy45MS0xMy04LjEsMC0xMy4xMSw1LjEzLTE0LjE0LDEzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTQ4Mi45LDY3Ljc1Yy45MSw4LjA5LDcuMDYsMTMsMTQuNywxMyw2Ljg0LDAsMTEuMjktMy4xOSwxNC43MS03LjQxbDkuOCw3LjQxYTI4LjQ5LDI4LjQ5LDAsMCwxLTIzLjE0LDExYy0xNi41MywwLTI5Ljc1LTExLjUyLTI5Ljc1LTI4LjczUzQ4Mi40NCwzNC4yMyw0OTksMzQuMjNjMTUuMjgsMCwyNS42NSwxMC43MiwyNS42NSwyOS43NnYzLjc2Wm0yOC0xMC4yNmMtLjExLTgtNS4zNi0xMy0xMy45MS0xMy04LjA5LDAtMTMuMTEsNS4xMy0xNC4xMywxM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MzcuMzksMzUuNmgxM3Y4Ljc4aC4yM2MyLjUxLTUuNDcsNy42NC0xMC4xNSwxNi43Ni0xMC4xNSwxNC43MSwwLDIwLDEwLjM4LDIwLDIxLjU1VjkwLjMySDU3My42NFY2Mi42MmMwLTYtLjQ2LTE2LjA4LTEwLTE2LjA4LTksMC0xMi41NCw2LjYyLTEyLjU0LDEzLjkxVjkwLjMySDUzNy4zOVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01OTYuNDQsNDcuMjNWMzUuNmgxMS4yOVYxOS43NWgxMy42OFYzNS42aDE1VjQ3LjIzaC0xNVY3MS4xN2MwLDUuNDcsMS41OSw4Ljg5LDcuNjMsOC44OSwyLjQsMCw1LjctLjQ2LDcuNDEtMS43MVY4OS44NmMtMi44NSwxLjM3LTcuNjQsMS44My0xMC44MywxLjgzLTE0LjQ3LDAtMTcuODktNi41LTE3Ljg5LTE5LjM4VjQ3LjIzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTY1OC4xMSw2Ny43NWMuOTEsOC4wOSw3LjA3LDEzLDE0LjcxLDEzLDYuODQsMCwxMS4yOC0zLjE5LDE0LjctNy40MWw5LjgxLDcuNDFhMjguNSwyOC41LDAsMCwxLTIzLjE0LDExYy0xNi41MywwLTI5Ljc2LTExLjUyLTI5Ljc2LTI4LjczczEzLjIzLTI4LjczLDI5Ljc2LTI4LjczYzE1LjI3LDAsMjUuNjQsMTAuNzIsMjUuNjQsMjkuNzZ2My43NlptMjgtMTAuMjZjLS4xMi04LTUuMzYtMTMtMTMuOTEtMTMtOC4xLDAtMTMuMTEsNS4xMy0xNC4xNCwxM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xODAuNTcsMTI5LjY1SDE5M2wzNC43Nyw4MC43MUgyMTEuMzVsLTcuNTItMTguNDdoLTM1bC03LjMsMTguNDdIMTQ1LjQ2Wm0xOC4yNCw0OS45My0xMi40Mi0zMi44My0xMi42NiwzMi44M1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0yMzUsMTU1LjY0aDEzdjguNTVoLjIzYzIuNC01LjEzLDcuNjQtOS45MiwxNi43Ni05LjkyLDguNDQsMCwxNC4yNSwzLjMxLDE3LjEsMTAuMTUsNC03LDkuOC0xMC4xNSwxOC0xMC4xNSwxNC41OSwwLDE5LjcyLDEwLjM4LDE5LjcyLDIzLjQ5djMyLjZIMzA2LjA4di0zMWMwLTYuODQtMi4wNS0xMi43Ni0xMC4xNC0xMi43Ni04LjU1LDAtMTEuNzQsNy4wNi0xMS43NCwxNC4xM3YyOS42NEgyNzAuNTJ2LTMyLjZjMC02LjczLTIuNzQtMTEuMTctOS4zNS0xMS4xNy05LDAtMTIuNTQsNi42MS0xMi41NCwxMy45djI5Ljg3SDIzNVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0zNjMuODgsMTcwLjhhMTIuNDMsMTIuNDMsMCwwLDAtMTAuNzEtNS41OGMtMy42NSwwLTgsMS43MS04LDUuODEsMCw5LjgxLDI5LjUyLDEuODIsMjkuNTIsMjMuMTQsMCwxMy0xMi40MiwxNy41Ni0yMy42LDE3LjU2LTguNDMsMC0xNS43My0yLjE3LTIxLjMxLTguNDRsOS4xMi04LjU1YzMuNTMsMy44OCw3LjE4LDYuNzMsMTMsNi43Myw0LDAsOS4xMi0xLjk0LDkuMTItNi4yNywwLTExLjI5LTI5LjUyLTIuMzktMjkuNTItMjMuMjYsMC0xMi4xOSwxMC45NC0xNy42NywyMi0xNy42Nyw3LjI5LDAsMTUuMDUsMi4yOCwxOS40OSw4LjMzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTM3OC45MywxNjcuMjdWMTU1LjY0aDExLjI4VjEzOS44aDEzLjY4djE1Ljg0aDE1LjA1djExLjYzSDQwMy44OXYyMy45NGMwLDUuNDcsMS42LDguODksNy42NCw4Ljg5LDIuNCwwLDUuNy0uNDYsNy40MS0xLjcxVjIwOS45Yy0yLjg1LDEuMzctNy42NCwxLjgzLTEwLjgzLDEuODMtMTQuNDgsMC0xNy45LTYuNS0xNy45LTE5LjM4VjE2Ny4yN1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00NDAuNiwxODcuNzljLjkxLDguMDksNy4wNywxMywxNC43MSwxMyw2Ljg0LDAsMTEuMjgtMy4xOSwxNC43LTcuNDFsOS44MSw3LjQxYTI4LjUxLDI4LjUxLDAsMCwxLTIzLjE1LDEwLjk1Yy0xNi41MiwwLTI5Ljc1LTExLjUxLTI5Ljc1LTI4LjczczEzLjIzLTI4LjczLDI5Ljc1LTI4LjczYzE1LjI4LDAsMjUuNjUsMTAuNzIsMjUuNjUsMjkuNzZ2My43NlptMjgtMTAuMjZjLS4xMS04LTUuMzUtMTMtMTMuOS0xMy04LjEsMC0xMy4xMSw1LjEzLTE0LjE0LDEzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTQ5NS4wOSwxNTUuNjRoMTMuNjh2OC42N0g1MDlhMTcuNDMsMTcuNDMsMCwwLDEsMTYuMTktMTAsMTcuODgsMTcuODgsMCwwLDEsNC45Ljh2MTMuMjJhMjcuNDUsMjcuNDUsMCwwLDAtNi42MS0xYy0xMi44OCwwLTE0LjcxLDEwLjgzLTE0LjcxLDEzLjc5djI5LjNINDk1LjA5WiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTU4MC44MiwyMDIuMTVoLS4yM2MtNCw2LjYyLTExLjE3LDkuNTgtMTguODEsOS41OC0xNi44NywwLTI3LTEyLjU0LTI3LTI4LjczczEwLjgzLTI4LjczLDI2LjQ1LTI4LjczYzEwLjI2LDAsMTUuNzMsNC43OSwxOC41OCw4LjMzaC4zNFYxMjQuMThoMTMuNjh2ODYuMThoLTEzWm0tMTYuMy0yLjczYzEwLDAsMTYuMDctNy44NywxNi4wNy0xNi40MnMtNi0xNi40MS0xNi4wNy0xNi40MS0xNi4wOCw3Ljg2LTE2LjA4LDE2LjQxUzU1NC40OCwxOTkuNDIsNTY0LjUyLDE5OS40MloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik02NDMuNTIsMjAyLjg0aC0uMzRjLTMuODgsNi4xNS0xMC4yNiw4Ljg5LTE3LjU2LDguODktMTAuMTUsMC0yMC01LjU5LTIwLTE2LjQyLDAtMTcuNzgsMjAuNzUtMTksMzQuNDMtMTloMy40MnYtMS40OGMwLTYuNzItNS4yNS0xMC4yNi0xMi41NC0xMC4yNmEyMS41LDIxLjUsMCwwLDAtMTQuNTksNS43bC03LjE5LTcuMThjNi02LjE2LDE0LjYtOC43OCwyMy4yNi04Ljc4LDIzLjM3LDAsMjMuMzcsMTYuODcsMjMuMzcsMjQuNjN2MzEuNDZINjQzLjUyWm0tLjgtMTdoLTIuODVjLTcuNTIsMC0yMC41Mi41Ny0yMC41Miw4LjQ0LDAsNSw1LjEzLDcuMTgsOS41OCw3LjE4LDkuMzQsMCwxMy43OS00LjksMTMuNzktMTIuNTRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNjcwLDE1NS42NGgxM3Y4LjU1aC4yM2MyLjM5LTUuMTMsNy42NC05LjkyLDE2Ljc2LTkuOTIsOC40MywwLDE0LjI1LDMuMzEsMTcuMSwxMC4xNSw0LTcsOS44LTEwLjE1LDE4LTEwLjE1LDE0LjU5LDAsMTkuNzIsMTAuMzgsMTkuNzIsMjMuNDl2MzIuNkg3NDEuMXYtMzFjMC02Ljg0LTIuMDUtMTIuNzYtMTAuMTUtMTIuNzYtOC41NSwwLTExLjc0LDcuMDYtMTEuNzQsMTQuMTN2MjkuNjRINzA1LjUzdi0zMi42YzAtNi43My0yLjczLTExLjE3LTkuMzUtMTEuMTctOSwwLTEyLjU0LDYuNjEtMTIuNTQsMTMuOXYyOS44N0g2NzBaIi8+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjAgMzIwLjE5IDMwIDI5MC4xOSAwIDI2MC4xOSAyMCAyNDAuMTkgNTAgMjcwLjE5IDgwIDI0MC4xOSAxMDAgMjYwLjE5IDcwIDI5MC4xOSAxMDAgMzIwLjE5IDgwIDM0MC4xOSA1MCAzMTAuMTkgMjAgMzQwLjE5IDAgMzIwLjE5Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjAgODAgMzAgNTAgMCAyMCAyMCAwIDUwIDMwIDgwIDAgMTAwIDIwIDcwIDUwIDEwMCA4MCA4MCAxMDAgNTAgNzAgMjAuMDEgMTAwIDAgODAiLz48cG9seWdvbiBjbGFzcz0iY2xzLTEiIHBvaW50cz0iMCAyMDAuMiAzMCAxNzAuMiAwIDE0MC4yIDIwIDEyMC4yIDUwIDE1MC4yIDgwIDEyMC4yIDEwMCAxNDAuMiA3MCAxNzAuMiAxMDAgMjAwLjIgODAgMjIwLjIgNTAgMTkwLjIgMjAgMjIwLjIgMCAyMDAuMiIvPjwvc3ZnPg==" width="64" height="30" alt="XXX"> <span class="header_title">Data en informatie</span> </a> </div>
+<div class="c-page__toegang-geweigerd">Toegang geweigerd (403)</div>
+<div>
+        <div class="c-page__content">
+        <div class="c-page__alleen-toegankelijk">Alleen toegankelijk voor beheerders van de sensoren register van Gemeente Amsterdam</div>
+        <div class="c-page__heeft-u-vragen">Heeft u vragen? Neem dan <a href="mailto:datapunt@amsterdam.nl">contact</a> met ons op.</div>
+    </div>
+    </div>
+
+
+</body></html>


### PR DESCRIPTION
Momenteel als een gebruiker is wel ingelogd, maar mag de admin niet bekijken (omdat die niet de juiste rol heeft) dan wordt er momenteel wordt de gebruiker geleid naar api.data.amsterdam.nl - dit is heel verwarrend. Met deze PR wordt de gebruiker nu geleid naar een 403 pagina:

![image](https://user-images.githubusercontent.com/879561/145216818-8649aa6c-7350-4102-a873-17ea2355ec64.png)
