### PR TITLE
TAO-787: Django admin geschiedenis voor excel import

### DIFF
--- a/api/src/iot/import_utils.py
+++ b/api/src/iot/import_utils.py
@@ -2,6 +2,7 @@ import contextlib
 import dataclasses
 import datetime
 import re
+from collections import Counter
 from itertools import islice, zip_longest
 from typing import Generator, Union
 
@@ -689,8 +690,7 @@ def import_xlsx(workbook, action_logger=lambda x: x):
         for person_data in {s.owner.email.lower(): s.owner for s in sensors}.values()
     }
 
-    num_created = 0
-    num_updated = 0
+    counter = Counter()
     errors = []
 
     for sensor_data in sensors:
@@ -698,9 +698,8 @@ def import_xlsx(workbook, action_logger=lambda x: x):
             validate_sensor(sensor_data)
             owner = people[sensor_data.owner.email.lower()]
             _, created = import_sensor(sensor_data, owner, action_logger)
-            num_created += int(created)
-            num_updated += int(not created)
+            counter.update([created])
         except Exception as e:
             errors.append(e)
 
-    return errors, num_created, num_updated
+    return errors, counter[True], counter[False]


### PR DESCRIPTION
Dit zorgt ervoor dat we vanuit de standaard django admin geschiedenis gebruiker acties kunnen loggen. Alle standaard admin acties werden al gelogd, maar dit zorgt ervoor dat ook het het importeren van een excel ook gelogd wordt. Hierdoor kunnen we een volledige historie opbouwen voor sensoren en hulptabellen.