### PR TITLE
TAO-815: Optimize DevicesViewSet to select and prefetch related

### DIFF
--- a/api/src/iot/views.py
+++ b/api/src/iot/views.py
@@ -34,7 +34,12 @@ class DevicesViewSet(DatapuntViewSet):
     """
     A view that will return the iot devices and makes it possible to post new ones
     """
-    queryset = Device2.objects.all()
+    queryset = (
+        Device2.objects.all()
+        .select_related('type', 'owner', 'legal_ground',)
+        .prefetch_related('themes', 'regions')
+        .order_by('id')
+    )
     serializer_class = Device2Serializer
     serializer_detail_class = Device2Serializer
 


### PR DESCRIPTION
Het viel mij op dat sensoren-register.amsterdam.nl een beetje sloom voelt. Het toevoegen van select_related and prefetch_related geeft een aardige speedup (dit is gemiddelde response tijd van 10 calls naar de GET endpoint):

![image](https://user-images.githubusercontent.com/879561/146017702-671bc339-bab1-4242-a0be-98c556d1d818.png)
